### PR TITLE
[fix]save location

### DIFF
--- a/script/download_data.sh
+++ b/script/download_data.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+mkdir -p data
 cd ./data
 wget https://www.rondhuit.com/download/ldcc-20140209.tar.gz
 tar -zxvf ldcc-20140209.tar.gz


### PR DESCRIPTION
## 関連URL
* https://github.com/nishiba/scdv/issues/2#issue-394093197

## 概要
* download_data.sh実行時にdataフォルダが存在しないためtextファイルがscdv直下に保存されmain.pyでデータの読み込みが出来ない
* download_data.shの最初の行にdataフォルダを作成するコードを追加
* これによりtextデータが適切にdataフォルダへ保存されmain.pyが正常に動作します．